### PR TITLE
Initialize controls correctly

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_libcamera/input_libcamera.cpp
+++ b/mjpg-streamer-experimental/plugins/input_libcamera/input_libcamera.cpp
@@ -124,7 +124,7 @@ int input_init(input_parameter *param, int plugin_no)
     context *pctx;
     context_settings *settings;
     int ret;
-    ControlList controls_;
+    ControlList controls_(controls::controls);
     int64_t frame_time;
     bool controls_flag = false;
     


### PR DESCRIPTION
Initialize controls correctly as "controls::controls"

This is necessary to stop the IPA process from aborting if it is running in "isolation" mode.

See: https://github.com/raspberrypi/libcamera-apps/pull/109 and https://github.com/raspberrypi/libcamera-apps/issues/90